### PR TITLE
Add response iteration and conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-  - 1.2.3
+  - 1.3
 otp_release:
   - 18.2
 sudo: false

--- a/lib/stripe/account.ex
+++ b/lib/stripe/account.ex
@@ -9,6 +9,8 @@ defmodule Stripe.Account do
 
   This module does not yet support managed accounts.
 
+  Does not yet render lists or take options.
+
   Stripe API reference: https://stripe.com/docs/api#account
   """
 
@@ -22,8 +24,35 @@ defmodule Stripe.Account do
     :transfers_enabled
   ]
 
+  @response_mapping %{
+    id: :string,
+    business_name: :string,
+    business_primary_color: :string,
+    business_url: :string,
+    charges_enabled: :boolean,
+    country: :string,
+    default_currency: :string,
+    details_submitted: :boolean,
+    display_name: :string,
+    email: :string,
+    managed: :boolean,
+    metadata: :metadata,
+    statement_descriptor: :string,
+    support_email: :string,
+    support_phone: :string,
+    support_url: :string,
+    timezone: :string,
+    transfers_enabled: :boolean
+  }
+
   @singular_endpoint "account"
   @plural_endpoint "accounts"
+
+  @doc """
+  Returns the Stripe response mapping of keys to types.
+  """
+  @spec response_mapping :: Keyword.t
+  def response_mapping, do: @response_mapping
 
   @doc """
   Retrieve your own account without options.
@@ -45,6 +74,6 @@ defmodule Stripe.Account do
 
   @spec do_retrieve(String.t, list) :: {:ok, t} | {:error, Exception.t}
   defp do_retrieve(endpoint, opts \\ []) do
-    Stripe.Request.retrieve(endpoint, %__MODULE__{}, opts)
+    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
   end
 end

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -19,6 +19,8 @@ defmodule Stripe.Card do
 
   This module does not yet support managed accounts.
 
+  Does not yet render lists or take options.
+
   Recipients may be deprecated for your version of the API. They have
   been replaced by managed accounts (see
   https://stripe.com/docs/connect/managed-accounts), which you should use
@@ -41,10 +43,42 @@ defmodule Stripe.Card do
     :tokenization_method
   ]
 
+  @response_mapping %{
+    id: :string,
+    address_city: :string,
+    address_country: :string,
+    address_line1: :string,
+    address_line1_check: :string,
+    address_line2: :string,
+    address_state: :string,
+    address_zip: :string,
+    address_zip_check: :string,
+    brand: :string,
+    country: :string,
+    customer: :string,
+    cvc_check: :string,
+    dynamic_last4: :string,
+    exp_month: :integer,
+    exp_year: :integer,
+    fingerprint: :string,
+    funding: :string,
+    last4: :string,
+    metadata: :metadata,
+    name: :string,
+    recipient: :string,
+    tokenization_method: :string
+  }
+
   @valid_update_keys [
     :address_city, :address_country, :address_line1, :address_line2,
     :address_state, :address_zip, :exp_month, :exp_year, :metadata, :name
   ]
+
+  @doc """
+  Returns the Stripe response mapping of keys to types.
+  """
+  @spec response_mapping :: Keyword.t
+  def response_mapping, do: @response_mapping
 
   defp endpoint_for_owner(owner_type, owner_id) do
     case owner_type do
@@ -72,7 +106,7 @@ defmodule Stripe.Card do
       |> Util.map_keys_to_atoms()
 
     case Stripe.request(:post, endpoint, body, %{}, opts) do
-      {:ok, result} -> {:ok, Util.stripe_response_to_struct(%__MODULE__{}, result)}
+      {:ok, result} -> {:ok, Util.stripe_map_to_struct(%__MODULE__{}, result)}
       {:error, error} -> {:error, error}
     end
   end
@@ -91,7 +125,7 @@ defmodule Stripe.Card do
   @spec retrieve(source, String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
   def retrieve(owner_type, owner_id, card_id, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
-    Stripe.Request.retrieve(endpoint, %__MODULE__{}, opts)
+    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
   end
 
   @doc """
@@ -102,7 +136,7 @@ defmodule Stripe.Card do
   @spec update(source, String.t, String.t, map, Keyword.t) :: {:ok, t} | {:error, Exception.t}
   def update(owner_type, owner_id, card_id, changes, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
-    Stripe.Request.update(endpoint, changes, @valid_update_keys, %__MODULE__{}, opts)
+    Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
   end
 
   @doc """

--- a/lib/stripe/connect/oauth.ex
+++ b/lib/stripe/connect/oauth.ex
@@ -45,22 +45,20 @@ defmodule Stripe.Connect.OAuth do
   @doc """
   Execute the OAuth callback to Stripe using the code supplied in the request parameter of the oauth redirect at the end of the onboarding workflow.
 
-## Example
-```
-{:ok, resp} = Stripe.Connect.token code
-IO.inspect resp
-%Stripe.Connect.OAuth.TokenResponse{
-  access_token: "ACCESS_TOKEN",
-  livemode: false,
-  refresh_token: "REFRESH_TOKEN",
-  scope: "read_write",
-  stripe_publishable_key: "PUBLISHABLE_KEY",
-  stripe_user_id: "USER_ID",
-  token_type: "bearer"
-}
-
-```
-
+  ## Example
+  ```
+  iex(1)> {:ok, resp} = Stripe.Connect.OAuth.token(code)
+  ...(1)> IO.inspect resp
+  %Stripe.Connect.OAuth.TokenResponse{
+      access_token: "ACCESS_TOKEN",
+      livemode: false,
+      refresh_token: "REFRESH_TOKEN",
+      scope: "read_write",
+      stripe_publishable_key: "PUBLISHABLE_KEY",
+      stripe_user_id: "USER_ID",
+      token_type: "bearer"
+  }
+  ```
   """
   @spec token(String.t) :: {:ok, map} | {:error, Exception.t}
   def token(code) do
@@ -73,7 +71,7 @@ IO.inspect resp
     }
 
     case Stripe.oauth_request(:post, endpoint, body) do
-       {:ok, result} -> {:ok, Util.stripe_response_to_struct(%TokenResponse{}, result)}
+       {:ok, result} -> {:ok, Util.stripe_map_to_struct(%TokenResponse{}, result)}
        {:error, error} -> {:error, error}
      end
   end
@@ -85,7 +83,7 @@ IO.inspect resp
 
   ## Example
   ```
-  Stripe.Connect.deauthorize(stripe_user_id)
+  iex(1)> {:ok, result} = Stripe.Connect.OAuth.deauthorize(stripe_user_id)
   ```
   """
   @spec deauthorize(String.t) :: {:ok, map} | {:error, Exception.t}
@@ -97,7 +95,7 @@ IO.inspect resp
     }
 
     case Stripe.oauth_request(:post, endpoint, body) do
-      {:ok, result} -> {:ok, Util.stripe_response_to_struct(%DeauthorizeResponse{}, result)}
+      {:ok, result} -> {:ok, Util.stripe_map_to_struct(%DeauthorizeResponse{}, result)}
       {:error, error} -> {:error, error}
     end
   end
@@ -105,6 +103,11 @@ IO.inspect resp
   @doc """
   Generate the URL to start a Stripe workflow. You can pass in a
   CSRF token to be sent to Stripe, which they send you back at the end of the workflow to further secure the interaction. Make sure you verify this token yourself upon receipt of the callback.
+
+  ## Example
+  ```
+  iex(1)> {:ok, result} = Stripe.Connect.OAuth.authorize_url(csrf_token)
+  ```
   """
   @spec authorize_url(String.t) :: {:ok, map} | {:error, Exception.t}
   def authorize_url(csrf_token) do

--- a/lib/stripe/convert.ex
+++ b/lib/stripe/convert.ex
@@ -1,0 +1,13 @@
+defmodule Stripe.Convert do
+  @moduledoc false
+
+  @doc """
+  Converts data into its necessary format.
+  """
+  def with_format(nil, :datetime), do: nil
+  def with_format(value, :datetime) do
+    {:ok, result} = DateTime.from_unix(value)
+    result
+  end
+  def with_format(value, _), do: value
+end

--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -9,6 +9,8 @@ defmodule Stripe.Customer do
   - Update a customer
   - Delete a customer
 
+  Does not yet render lists or take options.
+
   Stripe API reference: https://stripe.com/docs/api#customer
   """
 
@@ -18,28 +20,48 @@ defmodule Stripe.Customer do
 
   defstruct [
     :id, :account_balance, :business_vat_id, :created, :currency,
-    :default_source, :delinquent, :description, :discount, :email, :livemode,
-    :metadata, :shipping, :sources, :subscriptions
+    :default_source, :delinquent, :description, :email, :livemode,
+    :metadata
   ]
+
+  @response_mapping %{
+    id: :string,
+    account_balance: :string,
+    business_vat_id: :string,
+    created: :datetime,
+    currency: :string,
+    default_source: :string,
+    delinquent: :boolean,
+    description: :string,
+    email: :string,
+    livemode: :boolean,
+    metadata: :metadata
+  }
 
   @plural_endpoint "customers"
 
   @valid_create_keys [
     :account_balance, :business_vat_id, :coupon, :description, :email,
-    :metadata, :plan, :quantity, :shipping, :source, :tax_percent, :trial_end
+    :metadata, :plan, :quantity, :tax_percent, :trial_end
   ]
 
   @valid_update_keys [
     :account_balance, :business_vat_id, :coupon, :default_source, :description,
-    :email, :metadata, :shipping, :source
+    :email, :metadata
   ]
+
+  @doc """
+  Returns the Stripe response mapping of keys to types.
+  """
+  @spec response_mapping :: Keyword.t
+  def response_mapping, do: @response_mapping
 
   @doc """
   Create a customer.
   """
   @spec create(t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
   def create(customer, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, customer, @valid_create_keys, %__MODULE__{}, opts)
+    Stripe.Request.create(@plural_endpoint, customer, @valid_create_keys, __MODULE__, opts)
   end
 
   @doc """
@@ -48,7 +70,7 @@ defmodule Stripe.Customer do
   @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Exception.t}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, %__MODULE__{}, opts)
+    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
   end
 
   @doc """
@@ -59,7 +81,7 @@ defmodule Stripe.Customer do
   @spec update(t, map, list) :: {:ok, t} | {:error, Exception.t}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @valid_update_keys, %__MODULE__{}, opts)
+    Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
   end
 
   @doc """

--- a/lib/stripe/plan.ex
+++ b/lib/stripe/plan.ex
@@ -9,19 +9,33 @@ defmodule Stripe.Plan do
   - Update a plan
   - Delete a plan
 
+  Does not yet render lists or take options.
+
   Stripe API reference: https://stripe.com/docs/api#plan
   """
 
   alias Stripe.Util
 
   @type t :: %__MODULE__{}
-  @type stripe_response :: {:ok, t} | {:error, Exception.t}
-  @type stripe_delete_response :: :ok | {:error, Exception.t}
 
   defstruct [
     :id, :amount, :created, :currency, :interval, :interval_count,
     :livemode, :metadata, :name, :statement_descriptor, :trial_period_days
   ]
+
+  @response_mapping %{
+    id: :string,
+    amount: :integer,
+    created: :datetime,
+    currency: :string,
+    interval: :string,
+    interval_count: :integer,
+    livemode: :boolean,
+    metadata: :metadata,
+    name: :string,
+    statement_descriptor: :string,
+    trial_period_days: :integer
+  }
 
   @plural_endpoint "plans"
 
@@ -35,20 +49,26 @@ defmodule Stripe.Plan do
   ]
 
   @doc """
+  Returns the Stripe response mapping of keys to types.
+  """
+  @spec response_mapping :: Keyword.t
+  def response_mapping, do: @response_mapping
+
+  @doc """
   Create a plan.
   """
-  @spec create(t, Keyword.t) :: stripe_response
+  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
   def create(plan, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, plan, @valid_create_keys, %__MODULE__{}, opts)
+    Stripe.Request.create(@plural_endpoint, plan, @valid_create_keys, __MODULE__, opts)
   end
 
   @doc """
   Retrieve a plan.
   """
-  @spec retrieve(binary, Keyword.t) :: stripe_response
+  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Exception.t}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, %__MODULE__{}, opts)
+    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
   end
 
   @doc """
@@ -56,16 +76,16 @@ defmodule Stripe.Plan do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: stripe_response
+  @spec update(t, map, list) :: {:ok, t} | {:error, Exception.t}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @valid_update_keys, %__MODULE__{}, opts)
+    Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
   end
 
   @doc """
   Delete a plan.
   """
-  @spec delete(binary, list) :: stripe_delete_response
+  @spec delete(binary, list) :: :ok | {:error, Exception.t}
   def delete(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.delete(endpoint, opts)

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -1,32 +1,29 @@
 defmodule Stripe.Request do
   alias Stripe.Util
 
-  @type stripe_response :: {:ok, struct} | {:error, Exception.t}
-  @type stripe_delete_response :: :ok | {:error, Exception.t}
-
-  @spec create(String.t, struct, map, struct, Keyword.t) :: stripe_response
-  def create(endpoint, struct, valid_keys, return_struct, opts) do
+  @spec create(String.t, struct, map, module, Keyword.t) :: {:ok, struct} | {:error, Exception.t}
+  def create(endpoint, struct, valid_keys, module, opts) do
     body =
       struct
       |> Map.take(valid_keys)
       |> Util.drop_nil_keys()
 
     case Stripe.request(:post, endpoint, body, %{}, opts) do
-      {:ok, result} -> {:ok, Util.stripe_response_to_struct(return_struct, result)}
+      {:ok, result} -> {:ok, Util.stripe_map_to_struct(module, result)}
       {:error, error} -> {:error, error}
     end
   end
 
-  @spec retrieve(String.t, struct, Keyword.t) :: stripe_response
-  def retrieve(endpoint, return_struct, opts) do
+  @spec retrieve(String.t, module, Keyword.t) :: {:ok, struct} | {:error, Exception.t}
+  def retrieve(endpoint, module, opts) do
     case Stripe.request(:get, endpoint, %{}, %{}, opts) do
-      {:ok, result} -> {:ok, Util.stripe_response_to_struct(return_struct, result)}
+      {:ok, result} -> {:ok, Util.stripe_map_to_struct(module, result)}
       {:error, error} -> {:error, error}
     end
   end
 
-  @spec update(String.t, map, map, struct, Keyword.t) :: stripe_response
-  def update(endpoint, changes, valid_keys, return_struct, opts) do
+  @spec update(String.t, map, map, struct, Keyword.t) :: {:ok, struct} | {:error, Exception.t}
+  def update(endpoint, changes, valid_keys, module, opts) do
     body =
       changes
       |> Util.map_keys_to_atoms()
@@ -34,12 +31,12 @@ defmodule Stripe.Request do
       |> Util.drop_nil_keys()
 
     case Stripe.request(:post, endpoint, body, %{}, opts) do
-      {:ok, result} -> {:ok, Util.stripe_response_to_struct(return_struct, result)}
+      {:ok, result} -> {:ok, Util.stripe_map_to_struct(module, result)}
       {:error, error} -> {:error, error}
     end
   end
 
-  @spec delete(String.t, Keyword.t) :: stripe_delete_response
+  @spec delete(String.t, Keyword.t) :: :ok | {:error, Exception.t}
   def delete(endpoint, opts) do
     case Stripe.request(:delete, endpoint, %{}, %{}, opts) do
       {:ok, _} -> :ok

--- a/lib/stripe/subscription.ex
+++ b/lib/stripe/subscription.ex
@@ -9,21 +9,42 @@ defmodule Stripe.Subscription do
   - Update a subscription
   - Delete a subscription
 
+  Does not yet render lists or take options.
+
   Stripe API reference: https://stripe.com/docs/api#subscription
   """
 
   alias Stripe.Util
 
   @type t :: %__MODULE__{}
-  @type stripe_response :: {:ok, t} | {:error, Exception.t}
-  @type stripe_delete_response :: :ok | {:error, Exception.t}
 
   defstruct [
     :id, :application_fee_percent, :cancel_at_period_end, :canceled_at,
     :created, :current_period_end, :current_period_start, :customer,
-    :discount, :ended_at, :livemode, :metadata, :plan, :quantity, :source,
+    :ended_at, :livemode, :metadata, :plan, :quantity, :source,
     :start, :status, :tax_percent, :trial_end, :trial_start
   ]
+
+  @response_mapping %{
+    id: :string,
+    application_fee_percent: :float,
+    cancel_at_period_end: :boolean,
+    canceled_at: :datetime,
+    created: :datetime,
+    current_period_end: :datetime,
+    current_period_start: :datetime,
+    customer: :string,
+    ended_at: :datetime,
+    livemode: :boolean,
+    metadata: :metadata,
+    plan: %{module: Stripe.Plan},
+    quantity: :integer,
+    start: :datetime,
+    status: :string,
+    tax_percent: :float,
+    trial_end: :datetime,
+    trial_start: :datetime
+  }
 
   @plural_endpoint "subscriptions"
 
@@ -38,20 +59,26 @@ defmodule Stripe.Subscription do
   ]
 
   @doc """
+  Returns the Stripe response mapping of keys to types.
+  """
+  @spec response_mapping :: Keyword.t
+  def response_mapping, do: @response_mapping
+
+  @doc """
   Create a subscription.
   """
-  @spec create(t, Keyword.t) :: stripe_response
+  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
   def create(subscription, opts \\ []) do
-    Stripe.Request.create(@plural_endpoint, subscription, @valid_create_keys, %__MODULE__{}, opts)
+    Stripe.Request.create(@plural_endpoint, subscription, @valid_create_keys, __MODULE__, opts)
   end
 
   @doc """
   Retrieve a subscription.
   """
-  @spec retrieve(binary, Keyword.t) :: stripe_response
+  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Exception.t}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, %__MODULE__{}, opts)
+    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
   end
 
   @doc """
@@ -59,16 +86,16 @@ defmodule Stripe.Subscription do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: stripe_response
+  @spec update(t, map, list) :: {:ok, t} | {:error, Exception.t}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.update(endpoint, changes, @valid_update_keys, %__MODULE__{}, opts)
+    Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
   end
 
   @doc """
   Delete a subscription.
   """
-  @spec delete(binary, list) :: stripe_delete_response
+  @spec delete(binary, list) :: :ok | {:error, Exception.t}
   def delete(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.delete(endpoint, opts)

--- a/lib/stripe/token.ex
+++ b/lib/stripe/token.ex
@@ -7,18 +7,27 @@ defmodule Stripe.Token do
   - Create a token for a Connect customer with a card
   - Retrieve a token
 
+  Does not yet render lists or take options.
+
   Stripe API reference: https://stripe.com/docs/api#token
   """
 
   alias Stripe.Util
 
   @type t :: %__MODULE__{}
-  @type stripe_response :: {:ok, t} | {:error, Exception.t}
-  @type stripe_delete_response :: :ok | {:error, Exception.t}
 
   defstruct [
-    :id, :bank_account, :card, :client_ip, :created, :livemode, :type, :used
+    :id, :card, :client_ip, :created, :livemode, :type, :used
   ]
+
+  @response_mapping %{
+    id: :string,
+    card: %{module: Stripe.Card},
+    client_ip: :string,
+    created: :datetime,
+    livemode: :boolean,
+    used: :boolean
+  }
 
   @plural_endpoint "tokens"
 
@@ -27,26 +36,32 @@ defmodule Stripe.Token do
   ]
 
   @doc """
+  Returns the Stripe response mapping of keys to types.
+  """
+  @spec response_mapping :: Keyword.t
+  def response_mapping, do: @response_mapping
+
+  @doc """
   Create a token for a Connect customer with a card belonging to that customer.
 
   You must pass in the account number for the Stripe Connect account
   in `opts`.
   """
-  @spec create_on_connect_account(String.t, String.t, Keyword.t) :: stripe_response
+  @spec create_on_connect_account(String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
   def create_on_connect_account(customer_id, customer_card_id, opts = [connect_account: _]) do
     body = %{
       card: customer_card_id,
       customer: customer_id
     }
-    Stripe.Request.create(@plural_endpoint, body, @valid_create_connect_keys, %__MODULE__{}, opts)
+    Stripe.Request.create(@plural_endpoint, body, @valid_create_connect_keys, __MODULE__, opts)
   end
 
   @doc """
   Retrieve a token.
   """
-  @spec retrieve(binary, Keyword.t) :: stripe_response
+  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Exception.t}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
-    Stripe.Request.retrieve(endpoint, %__MODULE__{}, opts)
+    Stripe.Request.retrieve(endpoint, __MODULE__, opts)
   end
 end

--- a/lib/stripe/uri.ex
+++ b/lib/stripe/uri.ex
@@ -1,7 +1,5 @@
 defmodule Stripe.URI do
-  @moduledoc """
-  Stripe URI helpers to encode nested dictionaries as query_params.
-  """
+  @moduledoc false
 
   defmacro __using__(_) do
     quote do

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Stripe.Mixfile do
       app: :stripity_stripe,
       deps: deps,
       description: description(),
-      elixir: "~> 1.1",
+      elixir: "~> 1.3",
       package: package(),
       preferred_cli_env: [
         "coveralls": :test,
@@ -15,7 +15,7 @@ defmodule Stripe.Mixfile do
         "coveralls.html": :test
       ],
       test_coverage: [tool: ExCoveralls],
-      version: "2.0.0-alpha.1"
+      version: "2.0.0-alpha.2"
     ]
   end
 


### PR DESCRIPTION
This PR reworks Stripe response handling to iterate over the response and convert necessary values.

This does not yet handle lists from Stripe nor take in options to push to Stripe.

Reduces scope of certain struct keys as a result.