### PR TITLE
Fix Parsing OAuth Errors

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -127,7 +127,7 @@ defmodule Stripe do
     defexception [:message, :error, :state, :status_code]
 
     def exception(opts) do
-      struct(opts)
+      struct(__MODULE__, opts)
     end
   end
 


### PR DESCRIPTION
This fixes #130. I discussed with @JoshSmith. It seems the issue came about because of an inconsistency between Stripe's Connect API and its main API with regards to presenting errors. This change causes us to switch our representation to the newly created `Stripe.OAuthAPIError` struct when an issue arises with the Connect API in order to appropriately represent the data returned.