### PR TITLE
Fixes Struct Mapping

### DIFF
--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -106,7 +106,7 @@ defmodule Stripe.Card do
       |> Util.map_keys_to_atoms()
 
     case Stripe.request(:post, endpoint, body, %{}, opts) do
-      {:ok, result} -> {:ok, Util.stripe_map_to_struct(%__MODULE__{}, result)}
+      {:ok, result} -> {:ok, Util.stripe_map_to_struct(__MODULE__, result)}
       {:error, error} -> {:error, error}
     end
   end

--- a/lib/stripe/connect/oauth.ex
+++ b/lib/stripe/connect/oauth.ex
@@ -71,7 +71,7 @@ defmodule Stripe.Connect.OAuth do
     }
 
     case Stripe.oauth_request(:post, endpoint, body) do
-       {:ok, result} -> {:ok, Util.stripe_map_to_struct(%TokenResponse{}, result)}
+       {:ok, result} -> {:ok, Util.stripe_map_to_struct(TokenResponse, result)}
        {:error, error} -> {:error, error}
      end
   end
@@ -95,7 +95,7 @@ defmodule Stripe.Connect.OAuth do
     }
 
     case Stripe.oauth_request(:post, endpoint, body) do
-      {:ok, result} -> {:ok, Util.stripe_map_to_struct(%DeauthorizeResponse{}, result)}
+      {:ok, result} -> {:ok, Util.stripe_map_to_struct(DeauthorizeResponse, result)}
       {:error, error} -> {:error, error}
     end
   end


### PR DESCRIPTION
Fixes #131 

This was just an issue of trying to give the struct form of a module to the mapping function instead of the module itself.

@JoshSmith 