### PR TITLE
Rework errors to be plain structs

### DIFF
--- a/lib/stripe/account.ex
+++ b/lib/stripe/account.ex
@@ -57,22 +57,22 @@ defmodule Stripe.Account do
   @doc """
   Retrieve your own account without options.
   """
-  @spec retrieve :: {:ok, t} | {:error, Exception.t}
+  @spec retrieve :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve, do: retrieve([])
 
   @doc """
   Retrieve your own account with options.
   """
-  @spec retrieve(list) :: {:ok, t} | {:error, Exception.t}
+  @spec retrieve(list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(opts) when is_list(opts), do: do_retrieve(@singular_endpoint, opts)
 
   @doc """
   Retrieve an account with a specified `id`.
   """
-  @spec retrieve(binary, list) :: {:ok, t} | {:error, Exception.t}
+  @spec retrieve(binary, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []), do: do_retrieve(@plural_endpoint <> "/" <> id, opts)
 
-  @spec do_retrieve(String.t, list) :: {:ok, t} | {:error, Exception.t}
+  @spec do_retrieve(String.t, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   defp do_retrieve(endpoint, opts \\ []) do
     Stripe.Request.retrieve(endpoint, __MODULE__, opts)
   end

--- a/lib/stripe/card.ex
+++ b/lib/stripe/card.ex
@@ -98,7 +98,7 @@ defmodule Stripe.Card do
   If you want to create a card with your server without a token, you
   can use the low-level API.
   """
-  @spec create(source, String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec create(source, String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(owner_type, owner_id, token, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id)
     body =
@@ -122,7 +122,7 @@ defmodule Stripe.Card do
   @doc """
   Retrieve a card.
   """
-  @spec retrieve(source, String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec retrieve(source, String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(owner_type, owner_id, card_id, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
     Stripe.Request.retrieve(endpoint, __MODULE__, opts)
@@ -133,7 +133,7 @@ defmodule Stripe.Card do
 
   Takes the `id` and a map of changes
   """
-  @spec update(source, String.t, String.t, map, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec update(source, String.t, String.t, map, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(owner_type, owner_id, card_id, changes, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
     Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
@@ -142,7 +142,7 @@ defmodule Stripe.Card do
   @doc """
   Delete a card.
   """
-  @spec delete(source, String.t, String.t, Keyword.t) :: :ok | {:error, Exception.t}
+  @spec delete(source, String.t, String.t, Keyword.t) :: :ok | {:error, Stripe.api_error_struct}
   def delete(owner_type, owner_id, card_id, opts \\ []) do
     endpoint = endpoint_for_owner(owner_type, owner_id) <> "/" <> card_id
     Stripe.Request.delete(endpoint, opts)

--- a/lib/stripe/connect/oauth.ex
+++ b/lib/stripe/connect/oauth.ex
@@ -60,7 +60,7 @@ defmodule Stripe.Connect.OAuth do
   }
   ```
   """
-  @spec token(String.t) :: {:ok, map} | {:error, Exception.t}
+  @spec token(String.t) :: {:ok, map} | {:error, Stripe.api_error_struct}
   def token(code) do
     endpoint = "token"
 
@@ -86,7 +86,7 @@ defmodule Stripe.Connect.OAuth do
   iex(1)> {:ok, result} = Stripe.Connect.OAuth.deauthorize(stripe_user_id)
   ```
   """
-  @spec deauthorize(String.t) :: {:ok, map} | {:error, Exception.t}
+  @spec deauthorize(String.t) :: {:ok, map} | {:error, Stripe.api_error_struct}
   def deauthorize(stripe_user_id) do
     endpoint = "deauthorize"
     body = %{
@@ -109,17 +109,17 @@ defmodule Stripe.Connect.OAuth do
   iex(1)> {:ok, result} = Stripe.Connect.OAuth.authorize_url(csrf_token)
   ```
   """
-  @spec authorize_url(String.t) :: {:ok, map} | {:error, Exception.t}
+  @spec authorize_url(String.t) :: {:ok, map} | {:error, Stripe.api_error_struct}
   def authorize_url(csrf_token) do
     @authorize_url_base_body
     |> Map.put(:state, csrf_token)
     |> do_authorize_url()
   end
 
-  @spec authorize_url :: {:ok, map} | {:error, Exception.t}
+  @spec authorize_url :: {:ok, map} | {:error, Stripe.api_error_struct}
   def authorize_url, do: do_authorize_url(@authorize_url_base_body)
 
-  @spec do_authorize_url(map) :: {:ok, map} | {:error, Exception.t}
+  @spec do_authorize_url(map) :: {:ok, map} | {:error, Stripe.api_error_struct}
   defp do_authorize_url(body) do
     base_url = "https://connect.stripe.com/oauth/authorize?"
     body = Stripe.URI.encode_query(body)

--- a/lib/stripe/customer.ex
+++ b/lib/stripe/customer.ex
@@ -59,7 +59,7 @@ defmodule Stripe.Customer do
   @doc """
   Create a customer.
   """
-  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(customer, opts \\ []) do
     Stripe.Request.create(@plural_endpoint, customer, @valid_create_keys, __MODULE__, opts)
   end
@@ -67,7 +67,7 @@ defmodule Stripe.Customer do
   @doc """
   Retrieve a customer.
   """
-  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.retrieve(endpoint, __MODULE__, opts)
@@ -78,7 +78,7 @@ defmodule Stripe.Customer do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: {:ok, t} | {:error, Exception.t}
+  @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
@@ -87,7 +87,7 @@ defmodule Stripe.Customer do
   @doc """
   Delete a customer.
   """
-  @spec delete(binary, list) :: :ok | {:error, Exception.t}
+  @spec delete(binary, list) :: :ok | {:error, Stripe.api_error_struct}
   def delete(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.delete(endpoint, opts)

--- a/lib/stripe/plan.ex
+++ b/lib/stripe/plan.ex
@@ -57,7 +57,7 @@ defmodule Stripe.Plan do
   @doc """
   Create a plan.
   """
-  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(plan, opts \\ []) do
     Stripe.Request.create(@plural_endpoint, plan, @valid_create_keys, __MODULE__, opts)
   end
@@ -65,7 +65,7 @@ defmodule Stripe.Plan do
   @doc """
   Retrieve a plan.
   """
-  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.retrieve(endpoint, __MODULE__, opts)
@@ -76,7 +76,7 @@ defmodule Stripe.Plan do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: {:ok, t} | {:error, Exception.t}
+  @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
@@ -85,7 +85,7 @@ defmodule Stripe.Plan do
   @doc """
   Delete a plan.
   """
-  @spec delete(binary, list) :: :ok | {:error, Exception.t}
+  @spec delete(binary, list) :: :ok | {:error, Stripe.api_error_struct}
   def delete(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.delete(endpoint, opts)

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -1,7 +1,7 @@
 defmodule Stripe.Request do
   alias Stripe.Util
 
-  @spec create(String.t, struct, map, module, Keyword.t) :: {:ok, struct} | {:error, Exception.t}
+  @spec create(String.t, struct, map, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def create(endpoint, struct, valid_keys, module, opts) do
     body =
       struct
@@ -14,7 +14,7 @@ defmodule Stripe.Request do
     end
   end
 
-  @spec retrieve(String.t, module, Keyword.t) :: {:ok, struct} | {:error, Exception.t}
+  @spec retrieve(String.t, module, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def retrieve(endpoint, module, opts) do
     case Stripe.request(:get, endpoint, %{}, %{}, opts) do
       {:ok, result} -> {:ok, Util.stripe_map_to_struct(module, result)}
@@ -22,7 +22,7 @@ defmodule Stripe.Request do
     end
   end
 
-  @spec update(String.t, map, map, struct, Keyword.t) :: {:ok, struct} | {:error, Exception.t}
+  @spec update(String.t, map, map, struct, Keyword.t) :: {:ok, struct} | {:error, Stripe.api_error_struct}
   def update(endpoint, changes, valid_keys, module, opts) do
     body =
       changes
@@ -36,7 +36,7 @@ defmodule Stripe.Request do
     end
   end
 
-  @spec delete(String.t, Keyword.t) :: :ok | {:error, Exception.t}
+  @spec delete(String.t, Keyword.t) :: :ok | {:error, Stripe.api_error_struct}
   def delete(endpoint, opts) do
     case Stripe.request(:delete, endpoint, %{}, %{}, opts) do
       {:ok, _} -> :ok

--- a/lib/stripe/subscription.ex
+++ b/lib/stripe/subscription.ex
@@ -67,7 +67,7 @@ defmodule Stripe.Subscription do
   @doc """
   Create a subscription.
   """
-  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec create(t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create(subscription, opts \\ []) do
     Stripe.Request.create(@plural_endpoint, subscription, @valid_create_keys, __MODULE__, opts)
   end
@@ -75,7 +75,7 @@ defmodule Stripe.Subscription do
   @doc """
   Retrieve a subscription.
   """
-  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.retrieve(endpoint, __MODULE__, opts)
@@ -86,7 +86,7 @@ defmodule Stripe.Subscription do
 
   Takes the `id` and a map of changes.
   """
-  @spec update(t, map, list) :: {:ok, t} | {:error, Exception.t}
+  @spec update(t, map, list) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def update(id, changes, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.update(endpoint, changes, @valid_update_keys, __MODULE__, opts)
@@ -95,7 +95,7 @@ defmodule Stripe.Subscription do
   @doc """
   Delete a subscription.
   """
-  @spec delete(binary, list) :: :ok | {:error, Exception.t}
+  @spec delete(binary, list) :: :ok | {:error, Stripe.api_error_struct}
   def delete(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.delete(endpoint, opts)

--- a/lib/stripe/token.ex
+++ b/lib/stripe/token.ex
@@ -47,7 +47,7 @@ defmodule Stripe.Token do
   You must pass in the account number for the Stripe Connect account
   in `opts`.
   """
-  @spec create_on_connect_account(String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec create_on_connect_account(String.t, String.t, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def create_on_connect_account(customer_id, customer_card_id, opts = [connect_account: _]) do
     body = %{
       card: customer_card_id,
@@ -59,7 +59,7 @@ defmodule Stripe.Token do
   @doc """
   Retrieve a token.
   """
-  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Exception.t}
+  @spec retrieve(binary, Keyword.t) :: {:ok, t} | {:error, Stripe.api_error_struct}
   def retrieve(id, opts \\ []) do
     endpoint = @plural_endpoint <> "/" <> id
     Stripe.Request.retrieve(endpoint, __MODULE__, opts)


### PR DESCRIPTION
@JoshSmith This is what I discussed with you and @tlvenn over in #132. This reforms the exceptions that were being created into plain structs. They still carry largely the same information. I have retained the `MissingAPIKeyError` as an actual error.

Also, to avoid confusion, I have refrained from naming the plain structs ending in `Error`, as that is typically reserved for actual exceptions per the naming documentation.

I suggest that we use this to close #132. Soon we can also implement dialyzer which will catch more of this upfront as @tlvenn mentioned.